### PR TITLE
Fix button text in list template

### DIFF
--- a/base/templates/list.html
+++ b/base/templates/list.html
@@ -39,7 +39,7 @@
 
 
 </style>
-<a href="{% url 'uncategorized_tasks' %}" class="button is-primary">Uncategoried</a>
+<a href="{% url 'uncategorized_tasks' %}" class="button is-primary">Uncategorized</a>
 
 <div class="container">
     <div class="section">


### PR DESCRIPTION
## Summary
- fix spelling of 'Uncategorized' button in list template

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68408d273ab48327b2799ec9d73b16cd