### PR TITLE
Add basic model tests

### DIFF
--- a/DuoTasker/test_settings.py
+++ b/DuoTasker/test_settings.py
@@ -1,0 +1,14 @@
+from .settings import *
+
+# Use SQLite in-memory database for tests
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+SECRET_KEY = 'test-secret-key'
+DEBUG = True
+ALLOWED_HOSTS = ['*']
+CSRF_TRUSTED_ORIGINS = ['http://testserver']

--- a/base/tests.py
+++ b/base/tests.py
@@ -1,3 +1,18 @@
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Category, Task
+
+
+class CategoryModelTest(TestCase):
+    def test_str_returns_name(self):
+        category = Category.objects.create(name="Home", icon="home")
+        self.assertEqual(str(category), "Home")
+
+
+class TaskModelTest(TestCase):
+    def test_create_task_with_category(self):
+        category = Category.objects.create(name="Work", icon="briefcase")
+        task = Task.objects.create(title="Finish report", category=category)
+        self.assertEqual(str(task), "Finish report")
+        self.assertEqual(task.category, category)
+


### PR DESCRIPTION
## Summary
- write model tests for Category and Task
- add test settings using in-memory SQLite DB for tests

## Testing
- `python manage.py test --settings=DuoTasker.test_settings`

------
https://chatgpt.com/codex/tasks/task_e_68408d89c690832786dd47dcde475749