### PR TITLE
Fix keyword check for uncategorized tasks

### DIFF
--- a/base/views.py
+++ b/base/views.py
@@ -129,8 +129,9 @@ def uncategorized_tasks(request):
             category = Category.objects.get(id=category_id)
 
             # Assuming your Category model has a `keywords` field that is a comma-separated string
-            if task.name not in category.keywords:
-                category.keywords = f"{category.keywords},{task.name}" if category.keywords else task.name
+            # Ensure category keywords exist before checking for the task title
+            if not category.keywords or task.title not in category.keywords:
+                category.keywords = f"{category.keywords},{task.title}" if category.keywords else task.title
                 category.save()
 
             # Update the task's category if necessary


### PR DESCRIPTION
## Summary
- update uncategorized task keyword logic to use `task.title`
- avoid `None` errors when checking category keywords

## Testing
- `python manage.py test` *(fails: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68408ea54ca48327be5a669d51976dcf