### PR TITLE
Fix DB_NAME spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ DJANGO_SUPERUSER_EMAIL=admin@example.com
 DJANGO_SUPERUSER_PASSWORD=adminpassword
 
 # Database
-DB_NAME=duotakser
+DB_NAME=duotasker
 DB_USER=duotasker
 DB_PASSWORD=duotasker
 DB_HOST=postgres


### PR DESCRIPTION
## Summary
- correct DB_NAME value in README's `.env` example

## Testing
- `DJANGO_SETTINGS_MODULE=DuoTasker.test_settings python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68408ea5ddc083279de8123ddcd6a922